### PR TITLE
Fix typo in AnimationLoader method name

### DIFF
--- a/MooTheCow/Animations/AnimationLoader.cs
+++ b/MooTheCow/Animations/AnimationLoader.cs
@@ -28,10 +28,10 @@ namespace MooTheCow
 
         static AnimationLoader()
         {
-            LoadAnimiations();
+            LoadAnimations();
         }
 
-        private static void LoadAnimiations()
+        private static void LoadAnimations()
         {
             var animationsDoc = GetAnimationsDoc();
             var animals = GetAnimalAnimationNode(animationsDoc);


### PR DESCRIPTION
## Summary
- correct `LoadAnimiations` typo to `LoadAnimations`
- update static constructor call

## Testing
- `dotnet build MooTheCow.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a3f8010832e865d75af68ed991e